### PR TITLE
jpf-nhandler's tests are failing on amd based machines

### DIFF
--- a/src/test/java/converter/specific/JPF2JVMjava_utilTest.java
+++ b/src/test/java/converter/specific/JPF2JVMjava_utilTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class JPF2JVMjava_utilTest extends TestJPF {
   // override vm.class and nhandler.resetVMState property as they may have been set by other extensions of JPF
-  private final static String[] JPF_ARGS = { "+test.vm.class = gov.nasa.jpf.vm.SingleProcessVM", "+test.nhandler.resetVMState=true" };
+  private final static String[] JPF_ARGS = { "+nhandler.spec.navigate=java.lang.String.*", "+test.vm.class = gov.nasa.jpf.vm.SingleProcessVM", "+test.nhandler.resetVMState=true" };
 
   private static MJIEnv env;
 

--- a/src/test/java/on_the_fly/StringTest.java
+++ b/src/test/java/on_the_fly/StringTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class StringTest extends TestJPF {
   // override vm.class property as it may have been set by other extensions of JPF
-  private final static String[] JPF_ARGS = { "+nhandler.spec.delegate=java.lang.String.*", 						"+test.vm.class = gov.nasa.jpf.vm.SingleProcessVM" };
+  private final static String[] JPF_ARGS = { "+test.vm.class = gov.nasa.jpf.vm.SingleProcessVM" };
 
   public static void main (String[] args){
     runTestsOfThisClass(args);


### PR DESCRIPTION
- Removed `nhandler.spec.delegate = java.lang.String.*` from `on_the_fly.StringTest` which is causing error and failing tests
- Fixes #11 