### PR TITLE
Fix illegal reflective access warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,9 @@ test {
         events "passed", "skipped", "failed"
     }
 
-    jvmArgs += ['--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED',
-                '--add-opens', 'java.base/jdk.internal.misc=ALL-UNNAMED',
-	            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
-                '--add-opens', 'java.base/java.util=ALL-UNNAMED',
-                '--add-opens','java.base/java.util.regex=ALL-UNNAMED',
-                '--add-opens','java.base/java.lang.reflect=ALL-UNNAMED'
-    ]
+    jvmArgs += ['--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED','--add-opens', 'java.base/jdk.internal.misc=ALL-UNNAMED','--add-opens',
+                'java.base/java.lang=ALL-UNNAMED','--add-opens', 'java.base/java.util=ALL-UNNAMED','--add-opens', 'java.base/java.util.regex=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED']
     
     afterSuite { testDescriptor, result ->
         if (!testDescriptor.parent) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,13 @@ test {
         events "passed", "skipped", "failed"
     }
 
-    jvmArgs += ['--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED', '--add-opens', 'java.base/jdk.internal.misc=ALL-UNNAMED', '--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED']
+    jvmArgs += ['--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED',
+                '--add-opens', 'java.base/jdk.internal.misc=ALL-UNNAMED',
+	            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+                '--add-opens','java.base/java.util.regex=ALL-UNNAMED',
+                '--add-opens','java.base/java.lang.reflect=ALL-UNNAMED'
+    ]
     
     afterSuite { testDescriptor, result ->
         if (!testDescriptor.parent) {


### PR DESCRIPTION
Fixed the illegal reflective access warnings by applying changes similar to jpf-core's gradle build (https://github.com/javapathfinder/jpf-core/pull/373) and the build completes without any warnings now.